### PR TITLE
removed self.moved from Mover(Timer)

### DIFF
--- a/module/pieisreal/games.py
+++ b/module/pieisreal/games.py
@@ -1093,7 +1093,6 @@ class Mover (Timer):
         self.move_by (self._dx, self._dy)
         if self._da:
             self.rotate_by (self._da)
-        self.moved ()
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
This item referred to nothing, and was no longer needed